### PR TITLE
Mapvote test

### DIFF
--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -1788,7 +1788,8 @@ void SpectatorClientEndFrame(gentity_t *ent)
 
 		if (((g_gametype.integer == GT_WOLF_CAMPAIGN || g_gametype.integer == GT_WOLF_STOPWATCH || g_gametype.integer == GT_WOLF_MAPVOTE || g_gametype.integer == GT_WOLF) && (g_xpSaver.integer & XPSF_ENABLE)) ||
 		    (g_gametype.integer == GT_WOLF_CAMPAIGN && (g_campaigns[level.currentCampaign].current != 0 && !level.newCampaign)) ||
-		    (g_gametype.integer == GT_WOLF_LMS && g_currentRound.integer != 0))
+		    (g_gametype.integer == GT_WOLF_LMS && g_currentRound.integer != 0) ||
+		    (g_gametype.integer == GT_WOLF_MAPVOTE && g_resetXPMapCount.integer > 0))
 		{
 			for (i = 0; i < SK_NUM_SKILLS; ++i)
 			{

--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -402,7 +402,8 @@ qboolean G_SendScore_Add(gentity_t *ent, int i, char *buf, int bufsize)
 
 		if (((g_gametype.integer == GT_WOLF_CAMPAIGN || g_gametype.integer == GT_WOLF_STOPWATCH || g_gametype.integer == GT_WOLF_MAPVOTE || g_gametype.integer == GT_WOLF) && (g_xpSaver.integer & XPSF_ENABLE)) ||
 		    (g_gametype.integer == GT_WOLF_CAMPAIGN && (g_campaigns[level.currentCampaign].current != 0 && !level.newCampaign)) ||
-		    (g_gametype.integer == GT_WOLF_LMS && g_currentRound.integer != 0))
+		    (g_gametype.integer == GT_WOLF_LMS && g_currentRound.integer != 0) ||
+		    (g_gametype.integer == GT_WOLF_MAPVOTE && g_resetXPMapCount.integer > 0))
 		{
 			for (j = SK_BATTLE_SENSE; j < SK_NUM_SKILLS; j++)
 			{

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -1557,6 +1557,11 @@ void G_InitGame(int levelTime, int randomSeed, int restart, int etLegacyServer, 
 
 	if (g_gametype.integer == GT_WOLF_MAPVOTE)
 	{
+		if (g_resetXPMapCount.integer > 0)
+		{
+			level.mapsSinceLastXPReset = trap_Cvar_VariableIntegerValue("g_mapsSinceLastXPReset");
+		}
+
 		if (level.mapsSinceLastXPReset == 0)
 		{
 			G_ClearMapXP();
@@ -1651,11 +1656,6 @@ void G_InitGame(int levelTime, int randomSeed, int restart, int etLegacyServer, 
 	if (g_gametype.integer == GT_WOLF_MAPVOTE)
 	{
 		char mapConfig[MAX_STRING_CHARS];
-
-		if (g_resetXPMapCount.integer > 0)
-		{
-			level.mapsSinceLastXPReset = trap_Cvar_VariableIntegerValue("g_mapsSinceLastXPReset");
-		}
 
 		if (g_mapConfigs.string[0] && g_resetXPMapCount.integer)
 		{
@@ -2088,7 +2088,8 @@ int QDECL SortRanks(const void *a, const void *b)
 
 		if (!(((g_gametype.integer == GT_WOLF_CAMPAIGN || g_gametype.integer == GT_WOLF_STOPWATCH || g_gametype.integer == GT_WOLF_MAPVOTE || g_gametype.integer == GT_WOLF) && (g_xpSaver.integer & XPSF_ENABLE)) ||
 		      (g_gametype.integer == GT_WOLF_CAMPAIGN && (g_campaigns[level.currentCampaign].current != 0 && !level.newCampaign)) ||
-		      (g_gametype.integer == GT_WOLF_LMS && g_currentRound.integer != 0)))
+		      (g_gametype.integer == GT_WOLF_LMS && g_currentRound.integer != 0) ||
+		      (g_gametype.integer == GT_WOLF_MAPVOTE && g_resetXPMapCount.integer > 0)))
 		{
 			// current map XPs only
 			totalXP[0] -= ca->sess.startxptotal;

--- a/src/game/g_match.c
+++ b/src/game/g_match.c
@@ -498,6 +498,7 @@ void G_createStatsJson(gentity_t *ent, void *target)
 	// Add skill points as necessary
 	if (((g_gametype.integer == GT_WOLF_CAMPAIGN || g_gametype.integer == GT_WOLF_STOPWATCH || g_gametype.integer == GT_WOLF_MAPVOTE || g_gametype.integer == GT_WOLF) && (g_xpSaver.integer & XPSF_ENABLE)) ||
 	    (g_gametype.integer == GT_WOLF_CAMPAIGN && (g_campaigns[level.currentCampaign].current != 0 && !level.newCampaign)) ||
+	    (g_gametype.integer == GT_WOLF_MAPVOTE && g_resetXPMapCount.integer > 0) ||
 	    (g_gametype.integer == GT_WOLF_LMS && g_currentRound.integer != 0))
 	{
 		for (i = SK_BATTLE_SENSE; i < SK_NUM_SKILLS; i++)
@@ -593,7 +594,7 @@ char *G_createStats(gentity_t *ent)
 	}
 
 	// Add skillpoints as necessary
-	f (((g_gametype.integer == GT_WOLF_CAMPAIGN || g_gametype.integer == GT_WOLF_STOPWATCH) && (g_xpSaver.integer & XPSF_ENABLE)) ||
+	if (((g_gametype.integer == GT_WOLF_CAMPAIGN || g_gametype.integer == GT_WOLF_STOPWATCH) && (g_xpSaver.integer & XPSF_ENABLE)) ||
 	    (g_gametype.integer == GT_WOLF_CAMPAIGN && (g_campaigns[level.currentCampaign].current != 0 && !level.newCampaign)) ||
 	    (g_gametype.integer == GT_WOLF_MAPVOTE && g_resetXPMapCount.integer > 0) ||
 	    (g_gametype.integer == GT_WOLF_LMS && g_currentRound.integer != 0))

--- a/src/game/g_prestige.c
+++ b/src/game/g_prestige.c
@@ -129,7 +129,10 @@ void G_GetClientPrestige(gclient_t *cl)
 	gentity_t *ent;
 
 	// disable for these game types
-	if (g_gametype.integer == GT_WOLF_CAMPAIGN || g_gametype.integer == GT_WOLF_STOPWATCH || g_gametype.integer == GT_WOLF_LMS)
+	// mapvote with g_resetXPMapCount behaves like a dynamic campaign: XP is reset
+	// every N maps, so prestige must not persist/restore XP across the reset
+	if (g_gametype.integer == GT_WOLF_CAMPAIGN || g_gametype.integer == GT_WOLF_STOPWATCH || g_gametype.integer == GT_WOLF_LMS ||
+	    (g_gametype.integer == GT_WOLF_MAPVOTE && g_resetXPMapCount.integer > 0))
 	{
 		return;
 	}
@@ -195,7 +198,10 @@ void G_SetClientPrestige(gclient_t *cl, qboolean streakUp)
 	qboolean  hasMapXPs = qfalse;
 
 	// disable for these game types
-	if (g_gametype.integer == GT_WOLF_CAMPAIGN || g_gametype.integer == GT_WOLF_STOPWATCH || g_gametype.integer == GT_WOLF_LMS)
+	// mapvote with g_resetXPMapCount behaves like a dynamic campaign: XP is reset
+	// every N maps, so prestige must not persist/restore XP across the reset
+	if (g_gametype.integer == GT_WOLF_CAMPAIGN || g_gametype.integer == GT_WOLF_STOPWATCH || g_gametype.integer == GT_WOLF_LMS ||
+	    (g_gametype.integer == GT_WOLF_MAPVOTE && g_resetXPMapCount.integer > 0))
 	{
 		return;
 	}


### PR DESCRIPTION
- typo fix-up
- moved the `g_mapsSinceLastXPReset` load to where the XP reset decision is actually made
- XP wasn't showing on the scoreboard after map change; since this behaves more like a campaign, it made sense to me to change that as well

Verified with `g_prestige` and `g_xpSaver` both on and off.

The prestige fix is questionable, I don't see why would you ever mix the two, it just came up when I was testing it, so take it or leave it.